### PR TITLE
Redirect to specific pages according to the app state

### DIFF
--- a/src/app/core/api/login.service.ts
+++ b/src/app/core/api/login.service.ts
@@ -46,12 +46,10 @@ export class LoginService {
             switchMap((userFromApi: any) => {
                 const user = User.apiToModel(userFromApi);
                 this.userService.setCurrentUser(user);
-                return concat(
-                    this.asyncacheService.setUser(userFromApi).pipe(
-                        switchMap((_: any) => {
-                            return this.loginRoutine(user);
-                        })
-                    ),
+                return this.asyncacheService.setUser(userFromApi).pipe(
+                    switchMap((_: any) => {
+                        return this.loginRoutine(user);
+                    })
                 );
             }),
             tap(() => { this.redirect(); })
@@ -118,11 +116,11 @@ export class LoginService {
         }
 
         return this.asyncacheService.getCountry().pipe(
-            tap((cachedCountryReturnValue: CachedCountryReturnValue) => {
-                if (cachedCountryReturnValue) {
-                    this.countriesService.selectedCountry = cachedCountryReturnValue.country;
+            tap((cachedCountry: CachedCountryReturnValue) => {
+                if (cachedCountry) {
+                    this.countriesService.selectedCountry = cachedCountry.country;
                     // If the country has just been changed, redirect to home page
-                    if (cachedCountryReturnValue.updatedInLastSession) {
+                    if (cachedCountry.updatedInLastSession) {
                         this.redirectUrl = '/';
                     }
                 } else {
@@ -134,7 +132,6 @@ export class LoginService {
 
     // Set the user in service
     private setUser(user: User) {
-
         if (user.get<boolean>('changePassword') === true) {
             this.redirectUrl = '/profile';
             this.snackbar.info(this.language.profile_change_password);
@@ -144,7 +141,6 @@ export class LoginService {
 
     // Set the language in cache
     private setLanguage(user: User): Observable<Language> {
-
         return this.asyncacheService.getLanguage().pipe(
             switchMap(language => {
                 if (language) {

--- a/src/app/core/countries/countries.service.ts
+++ b/src/app/core/countries/countries.service.ts
@@ -53,19 +53,6 @@ export class CountriesService {
     }
 
     //
-    // ─── SETTER ─────────────────────────────────────────────────────────────────────
-    //
-    public setCountry(country?: Country): Country {
-        if (!country) {
-            country = this.enabledCountries[0];
-        }
-        if (this.selectedCountry !== country) {
-            this.selectedCountry = country;
-        }
-        return country;
-    }
-
-    //
     // ─── HELPER FUNCTIONS ───────────────────────────────────────────────────────────
     //
     public clearCountries(): void {

--- a/src/app/core/storage/asyncache.service.ts
+++ b/src/app/core/storage/asyncache.service.ts
@@ -12,6 +12,7 @@ import { User } from 'src/app/models/user';
 import { CountriesService } from '../countries/countries.service';
 import { Language } from '../language/language';
 import { LanguageService } from '../language/language.service';
+import { CachedCountryReturnValue, CachedCountryValue } from './cached-country-value.interface';
 import { CachedItemInterface } from './cached-item.interface';
 
 @Injectable({
@@ -75,8 +76,8 @@ export class AsyncacheService {
             return of(this.formatKeyCountry(key, this.countriesService.selectedCountry));
         } else {
             return this.getCountry().pipe(
-                map((country: Country) => {
-                    return this.formatKeyCountry(key, country);
+                map((cachedCountryReturnValue: CachedCountryReturnValue) => {
+                    return this.formatKeyCountry(key, cachedCountryReturnValue.country);
                 })
             );
         }
@@ -116,7 +117,6 @@ export class AsyncacheService {
                     );
                 })
             )
-
         );
     }
 
@@ -129,7 +129,6 @@ export class AsyncacheService {
     set(key: string, value: any, options: any = {}): Observable<boolean> {
         return this.getFormattedKey(key).pipe(
             switchMap((formattedKey: string) => {
-
                 // this.localStorage.setItemSubscribe(formattedKey, value);
                 if (options.canBeDeleted == null) {
                     options.canBeDeleted = true;
@@ -233,24 +232,37 @@ export class AsyncacheService {
     // ─── COUNTRY UTILS ──────────────────────────────────────────────────────────────────────
     //
 
-    setCountry(country: Country): Observable<boolean> {
-        return this.set(AsyncacheService.COUNTRY, country.get<string>('id'));
+    setCountry(country: Country, updatedInLastSession: boolean = true): Observable<boolean> {
+        return this.set(AsyncacheService.COUNTRY,
+            {
+                countryId: country.get<string>('id'),
+                // To make the app go back to '/' on the next login
+                updatedInLastSession: updatedInLastSession,
+            }
+        );
     }
 
-    getCountry(): Observable<Country> {
-        // countries are stored in user object
+
+
+    getCountry(): Observable<CachedCountryReturnValue> {
         const countries: Array<Country> = this.countriesService.enabledCountries;
         if (this.countriesService.selectedCountry) {
-            return of(this.countriesService.selectedCountry);
+            return of({country: this.countriesService.selectedCountry, updatedInLastSession: false});
         }
         return this.get(AsyncacheService.COUNTRY).pipe(
-            map((countryId: string) => {
-                for (const country of countries) {
-                    if (country.get<string>('id') === countryId) {
-                        return country;
+            switchMap((countryCacheObject: CachedCountryValue) => {
+                if (countryCacheObject) {
+                    // Remove cache entry
+                    for (const country of countries) {
+                        if (country.get<string>('id') === countryCacheObject.countryId) {
+                            // Reset it and reset the updatedInLastSession to false
+                            return this.setCountry(country, false).pipe(
+                                map((_: any) => ({country, updatedInLastSession: countryCacheObject.updatedInLastSession}))
+                            );
+                        }
                     }
                 }
-                return undefined;
+                return of(undefined);
             }),
         );
     }

--- a/src/app/core/storage/asyncache.service.ts
+++ b/src/app/core/storage/asyncache.service.ts
@@ -242,8 +242,6 @@ export class AsyncacheService {
         );
     }
 
-
-
     getCountry(): Observable<CachedCountryReturnValue> {
         const countries: Array<Country> = this.countriesService.enabledCountries;
         if (this.countriesService.selectedCountry) {
@@ -252,7 +250,7 @@ export class AsyncacheService {
         return this.get(AsyncacheService.COUNTRY).pipe(
             switchMap((countryCacheObject: CachedCountryValue) => {
                 if (countryCacheObject) {
-                    // Remove cache entry
+                    // Reset updatedInLastSession
                     for (const country of countries) {
                         if (country.get<string>('id') === countryCacheObject.countryId) {
                             // Reset it and reset the updatedInLastSession to false

--- a/src/app/core/storage/cached-country-value.interface.ts
+++ b/src/app/core/storage/cached-country-value.interface.ts
@@ -1,0 +1,11 @@
+import { Country } from 'src/app/models/country';
+
+export interface CachedCountryValue {
+    countryId: string;
+    updatedInLastSession: boolean;
+}
+
+export interface CachedCountryReturnValue {
+    country: Country;
+    updatedInLastSession: boolean;
+}

--- a/src/app/modules/public/login.component.ts
+++ b/src/app/modules/public/login.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RecaptchaComponent } from 'ng-recaptcha';
+import { throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { LoginService } from 'src/app/core/api/login.service';
 import { UserService } from 'src/app/core/api/user.service';
 import { AuthenticationService } from 'src/app/core/authentication/authentication.service';
@@ -51,12 +53,15 @@ export class LoginComponent implements OnInit {
     public onSubmit(): void {
         const { username, password } = this.form.value;
         this.loader = true;
-        this.loginService.login(username, password).subscribe(
-            (success) => {
-                this.loginService.redirect(success.user);
+        this.loginService.login(username, password).pipe(
+            catchError((error: any) => {
                 this.loader = false;
-            },
-            (_error) => { this.loader = false; console.error(_error); }
+                return throwError(error);
+            })
+        ).subscribe(
+            (_success) => {
+                this.loader = false;
+            }
         );
     }
 


### PR DESCRIPTION
+ Add a field in the country cache entry to keep track of the country switches
~ Edit cache function according to this new field
+ Add interfaces to type this
~ Remove redirect in component and redirect in service instead
+ Add redirection patterns according to this:

```
- On login:
  - Redirect to / by default
  - Redirect to /profile if the user has to edit his password
- Otherwise:
  - Redirect to the last page by default
  - Redirect to / if the user was redirected because of a country switch
```